### PR TITLE
Use tf at depth_image_projector

### DIFF
--- a/opengl_ros/CMakeLists.txt
+++ b/opengl_ros/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   cv_bridge
   opengl_ros_lib
-  realsense2_camera
+  tf
 )
 
 ## System dependencies are found with CMake's conventions

--- a/opengl_ros/launch/depth_image_projection.launch
+++ b/opengl_ros/launch/depth_image_projection.launch
@@ -41,6 +41,10 @@
 
   <node pkg="opengl_ros" type="depth_image_projector"
     name="depth_image_projector" output="screen">
+    <param name="color_frame_id"            value="d435_color_optical"/>
+    <param name="depth_frame_id"            value="d435_depth_optical"/>
+    <param name="tf_wait_duration"          value="0.1"/>
+
     <param name="colorWidth"                value="$(arg depth_width)"/>
     <param name="colorHeight"               value="$(arg depth_height)"/>
     <param name="depthWidth"                value="$(arg depth_width)"/>

--- a/opengl_ros/package.xml
+++ b/opengl_ros/package.xml
@@ -45,7 +45,9 @@
   <build_depend>image_transport</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>opengl_ros_lib</build_depend> 
+  <build_depend>tf</build_depend> 
   <run_depend>opengl_ros_lib</run_depend> 
+  <run_depend>tf</run_depend> 
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/opengl_ros/src/depth_image_projector_nodecore.h
+++ b/opengl_ros/src/depth_image_projector_nodecore.h
@@ -6,9 +6,9 @@
 
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
-#include <realsense2_camera/Extrinsics.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <tf/transform_listener.h>
 
 #include "depth_image_projector.h"
 
@@ -19,6 +19,12 @@ class DepthImageProjectorNode
     //Handles
     ros::NodeHandle nh_;
     image_transport::ImageTransport it_;
+
+    // tf
+    std::string color_frame_id_;
+    std::string depth_frame_id_;
+    tf::TransformListener tfListener_;
+    double tf_wait_duration_;
 
     //Publishers and Subscribers
     image_transport::Publisher imagePublisher_;
@@ -36,7 +42,7 @@ class DepthImageProjectorNode
     void depthCallback(const sensor_msgs::Image::ConstPtr& imageMsg, const sensor_msgs::CameraInfoConstPtr & cameraInfoMsg);
     bool depthToColorArrived_ = false;
     std::array<float, 16> latestDepthToColor_;
-    void depthToColorCallback(const realsense2_camera::Extrinsics::ConstPtr& depthToColorMsg);
+    bool updateDepthToColor();
 
 public:
     DepthImageProjectorNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);


### PR DESCRIPTION
Use tf to cut unnecessary dependency with realsense2_camera and make
depth_image_projector enable to be used on not only realsense2 but other
color & depth image devices.